### PR TITLE
Add a withRelay Higher Order Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,43 @@ async function (res, req, next) {
 });
 ```
 
+```js
+
+import React from 'react';
+import {QueryRenderer} from 'react-relay';
+import {withRelay} from 'relay-context-provider';
+
+const MyComponent = ({relay}) => {
+  return <QueryRenderer
+    environment={relay.environment}
+    query={graphql`
+      query MyComponentQuery {
+        viewer {
+          fullName
+        }
+      }
+    `}
+    variables={{}}
+    render={({error, props}) => {
+      if (error) {
+        return <div>Error</div>;
+      }
+      if (!props) {
+        return <div>Loading</div>;
+      }
+      return <div>Got viewer: {props.viewer.fullName}</div>;
+    }}
+  />;
+};
+
+export default withRelay(MyComponent);
+```
+
 ### Isomorphic Example
 See the full isomorphic/universal/server side rendered example here: https://github.com/robrichard/relay-modern-isomorphic-example
+
+## Running Tests
+
+```bash
+yarn test
+```

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
   "author": "Rob Richard",
   "license": "MIT",
   "scripts": {
-    "compile": "babel ./src -d ./dist --ignore test.js"
+    "compile": "babel ./src -d ./dist --ignore test.js",
+    "test": "jest"
   },
   "dependencies": {
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "hoist-non-react-statics": "^2.3.1"
   },
   "peerDependencies": {
     "react": "^16.0.0-a || ^15.0.0 || ^0.14.0"
@@ -22,7 +24,9 @@
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
-    "jest": "^20.0.4"
+    "jest": "^20.0.4",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "files": [
     "dist"

--- a/src/__tests__/withRelay.test.js
+++ b/src/__tests__/withRelay.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import RelayContextProvider from "..";
-import withRelay from "../withRelay";
+import {withRelay} from "..";
 
 describe("withRelay", () => {
   const node = document.createElement("div");

--- a/src/__tests__/withRelay.test.js
+++ b/src/__tests__/withRelay.test.js
@@ -1,0 +1,75 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import RelayContextProvider from "..";
+import withRelay from "../withRelay";
+
+describe("withRelay", () => {
+  const node = document.createElement("div");
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(node);
+  });
+
+  it("provides { relay } prop", () => {
+    const environment = { internalStuff: '' };
+    const variables = { viewerId: '123' };
+
+    const PropsChecker = withRelay(props => {
+      expect(typeof props.relay).toBe("object");
+      expect(props.relay.environment).toBe(environment);
+      expect(props.relay.variables).toBe(variables);
+      return null;
+    });
+
+    ReactDOM.render(
+      <RelayContextProvider environment={environment} variables={variables}>
+        <PropsChecker />
+      </RelayContextProvider>,
+      node
+    );
+  });
+
+  it("exposes the wrapped component as WrappedComponent", () => {
+    const Component = () => <div />;
+    const decorated = withRelay(Component);
+    expect(decorated.WrappedComponent).toBe(Component);
+  });
+
+  it("exposes the instance of the wrapped component via wrappedComponentRef", () => {
+    class WrappedComponent extends React.Component {
+      render() {
+        return null;
+      }
+    }
+    const Component = withRelay(WrappedComponent);
+
+    let ref;
+    ReactDOM.render(
+      <RelayContextProvider environment={{}} variables={{}}>
+        <Component wrappedComponentRef={r => (ref = r)} />
+      </RelayContextProvider>,
+      node
+    );
+
+    expect(ref instanceof WrappedComponent).toBe(true);
+  });
+
+  it("hoists non-react statics from the wrapped component", () => {
+    class Component extends React.Component {
+      static foo() {
+        return "bar";
+      }
+
+      render() {
+        return null;
+      }
+    }
+    Component.hello = "world";
+
+    const decorated = withRelay(Component);
+
+    expect(decorated.hello).toBe("world");
+    expect(typeof decorated.foo).toBe("function");
+    expect(decorated.foo()).toBe("bar");
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 import {Component} from 'react';
 import PropTypes from 'prop-types';
+import withRelay from './withRelay';
+
+export {withRelay};
 
 /**
  * Creates Relay Context for child components

--- a/src/withRelay.js
+++ b/src/withRelay.js
@@ -1,0 +1,29 @@
+import React from "react";
+import PropTypes from "prop-types";
+import hoistStatics from "hoist-non-react-statics";
+
+/**
+ * A public higher-order component to access the imperative API
+ */
+const withRelay = (Component) => {
+  const C = (props, {relay}) => {
+    const { wrappedComponentRef, ...remainingProps } = props;
+    return <Component {...remainingProps} ref={wrappedComponentRef} relay={relay} />;
+  };
+
+  C.displayName = `withRelay(${Component.displayName || Component.name})`;
+  C.WrappedComponent = Component;
+  C.propTypes = {
+    wrappedComponentRef: PropTypes.func
+  };
+  C.contextTypes = {
+    relay: PropTypes.shape({
+      environment: PropTypes.object.isRequired,
+      variables: PropTypes.object.isRequired
+    })
+  };
+
+  return hoistStatics(C, Component);
+};
+
+export default withRelay;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1056,6 +1056,18 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
@@ -1266,6 +1278,10 @@ hawk@~3.1.3:
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
+
+hoist-non-react-statics@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -1844,7 +1860,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -1997,7 +2013,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.1.0:
+object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2174,6 +2190,14 @@ prop-types@^15.5.10:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -2201,6 +2225,24 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-dom@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Provides a convenient way of accessing the relay from the context, similar to [react-router's withRouter](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/withRouter.md) and [react-redux's connect](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options).

e.g.
```js
import React from 'react';
import {QueryRenderer} from 'react-relay';
import {withRelay} from 'relay-context-provider';

const MyComponent = ({relay}) => {
  return <QueryRenderer
    environment={relay.environment}
    query={graphql`
      query MyComponentQuery {
        viewer {
          fullName
        }
      }
    `}
    render={({error, props}) => {
      if (error) {
        return <div>Error</div>;
      }
      if (!props) {
        return <div>Loading</div>;
      }
      return <div>Got viewer: {props.viewer.fullName}</div>;
    }}
  />;
};

export default withRelay(MyComponent);
```